### PR TITLE
Style : Pretendard 폰트 추가 및 글로벌 적용

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -185,3 +185,47 @@
     }
   }
 }
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff2')
+    format('woff2');
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Regular.woff')
+    format('woff');
+  font-weight: 400;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff2')
+    format('woff2');
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Medium.woff')
+    format('woff');
+  font-weight: 500;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff2')
+    format('woff2');
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-SemiBold.woff')
+    format('woff');
+  font-weight: 600;
+  font-style: normal;
+  font-display: swap;
+}
+
+@font-face {
+  font-family: 'Pretendard';
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff2')
+    format('woff2');
+  src: url('https://fastly.jsdelivr.net/gh/Project-Noonnu/noonfonts_2107@1.1/Pretendard-Bold.woff')
+    format('woff');
+  font-weight: 700;
+  font-style: normal;
+  font-display: swap;
+}


### PR DESCRIPTION
## 🔎 작업 사항 
- 기존에 Regular만 적용되어 있었던 Pretendard 폰트에 대해 Medium, SemiBold, Bold 굵기별 @font-face를 추가했습니다.
- Tailwind의 `font-semibold`, `font-bold` 등의 클래스에서도 정확한 Pretendard 스타일이 적용되도록 구성했습니다.
- 기존 적용 누락분을 뒤늦게 반영하게 되어 죄송합니다 🙇‍♀️

## ✅ 확인 해주세요 
PR이 다음 요구 사항을 충족하는지 확인하세요.
* 담당자 설정 하셨나요?
* 라벨링 하셨나요?
* console.log 가 남아있진 않나요?
* 변경사항에 대한 테스트 하셨나요?
