### PR TITLE
Fix : 한 페이지에 서로 다른 Modal을 띄우지 못하는 오류 해결 

### DIFF
--- a/src/app/(content-layout)/[groupId]/tasklist/_tasklist/components/ModalContents/CreateTaskListModal.tsx
+++ b/src/app/(content-layout)/[groupId]/tasklist/_tasklist/components/ModalContents/CreateTaskListModal.tsx
@@ -24,11 +24,13 @@ export default function CreateTaskListModal() {
 
   return (
     <ModalProvider>
-      <ModalTrigger className="text-primary size-20 w-fit">+ 새로운 목록 추가하기</ModalTrigger>
-      <ModalPortal>
-        <ModalOverlay>
+      <ModalTrigger className="text-primary size-20 w-fit" modalId="1">
+        + 새로운 목록 추가하기
+      </ModalTrigger>
+      <ModalPortal modalId="1">
+        <ModalOverlay modalId="1">
           <ModalContainer>
-            <ModalCloseButton />
+            <ModalCloseButton modalId="1" />
             <ModalHeading>새로운 목록 추가</ModalHeading>
             <ModalDescription className="text-md-md text-gray500 mb-6 w-full">
               할 일에 대한 목록을 추가하고

--- a/src/app/(content-layout)/[groupId]/tasklist/_tasklist/components/ModalContents/RemoveTaskModalContent.tsx
+++ b/src/app/(content-layout)/[groupId]/tasklist/_tasklist/components/ModalContents/RemoveTaskModalContent.tsx
@@ -20,7 +20,7 @@ export function RemoveTaskModalContent({ taskName }: Props) {
     //삭제 요청
   };
   return (
-    <ModalOverlay>
+    <ModalOverlay modalId="1">
       <ModalContainer>
         <Image src="/icons/danger.icon.svg" alt="!" width={20} height={20} />
         <ModalHeading className="mt-4 mb-2">
@@ -31,7 +31,12 @@ export function RemoveTaskModalContent({ taskName }: Props) {
         </ModalDescription>
         <ModalFooter className="w-full">
           <div className="flex w-full gap-2">
-            <Button variant="outline-gray" onClick={closeModal} fontSize="16" size="fullWidth">
+            <Button
+              variant="outline-gray"
+              onClick={() => closeModal('1')}
+              fontSize="16"
+              size="fullWidth"
+            >
               닫기
             </Button>
             <Button variant="danger" onClick={handleClickDeleteTask} size="fullWidth">

--- a/src/app/(content-layout)/[groupId]/tasklist/_tasklist/components/ModalContents/RemoveTaskModalPopUp.tsx
+++ b/src/app/(content-layout)/[groupId]/tasklist/_tasklist/components/ModalContents/RemoveTaskModalPopUp.tsx
@@ -9,8 +9,8 @@ interface Props {
 export default function RemoveTaskModal({ taskName }: Props) {
   return (
     <ModalProvider>
-      <ModalTrigger>삭제하기</ModalTrigger>
-      <ModalPortal>
+      <ModalTrigger modalId="1">삭제하기</ModalTrigger>
+      <ModalPortal modalId="1">
         <RemoveTaskModalContent taskName={taskName} />
       </ModalPortal>
     </ModalProvider>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 import './globals.css';
 import Header from '@/components/layout/gnb/Header';
+import { ModalProvider } from '@/components/common/modal';
 
 export const metadata: Metadata = {
   title: 'Coworkers',
@@ -14,9 +15,11 @@ export default function RootLayout({
   return (
     <html lang="ko">
       <body className="flex min-h-screen flex-col">
-        <Header />
-        <div>{children}</div>
-        <div id="modal-container"></div>
+        <ModalProvider>
+          <Header />
+          <div>{children}</div>
+          <div id="modal-container"></div>
+        </ModalProvider>
       </body>
     </html>
   );

--- a/src/components/common/modal/core/ModalContext.tsx
+++ b/src/components/common/modal/core/ModalContext.tsx
@@ -2,10 +2,10 @@
 import { createContext } from 'react';
 
 type ModalContextValue = {
-  toggleModal: () => void;
-  openModal: () => void;
-  closeModal: () => void;
-  isOpen: boolean;
+  toggleModal: (id: string) => void;
+  openModal: (id: string) => void;
+  closeModal: (id: string) => void;
+  checkIsModalOpen: (id: string) => boolean;
 };
 
 const ModalContext = createContext<ModalContextValue | null>(null);

--- a/src/components/common/modal/core/ModalPortal.tsx
+++ b/src/components/common/modal/core/ModalPortal.tsx
@@ -3,9 +3,15 @@ import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
 import useModalContext from '@/components/common/modal/core/useModalContext';
 
-export default function ModalPortal({ children }: { children: React.ReactNode }) {
+export default function ModalPortal({
+  children,
+  modalId,
+}: {
+  children: React.ReactNode;
+  modalId: string;
+}) {
   const [modalPortal, setModalPortal] = useState<Element | null>(null);
-  const { isOpen } = useModalContext();
+  const { checkIsModalOpen } = useModalContext();
 
   useEffect(
     function initializeModalPortal() {
@@ -17,5 +23,5 @@ export default function ModalPortal({ children }: { children: React.ReactNode })
 
   if (!modalPortal) return null;
 
-  return <>{createPortal(isOpen ? children : null, modalPortal)}</>;
+  return <>{createPortal(checkIsModalOpen(modalId) ? children : null, modalPortal)}</>;
 }

--- a/src/components/common/modal/core/ModalProvider.tsx
+++ b/src/components/common/modal/core/ModalProvider.tsx
@@ -2,23 +2,47 @@
 import { useState } from 'react';
 import ModalContext from '@/components/common/modal/core/ModalContext';
 
+export interface ModalState {
+  [id: string]: { isOpen: boolean };
+}
+
 export default function ModalProvider({ children }: { children: React.ReactNode }) {
-  const [isOpen, setIsOpen] = useState(false);
+  const [modals, setModals] = useState<ModalState>({});
 
-  const toggleModal = () => {
-    setIsOpen((prev) => !prev);
+  const openModal = (id: string) => {
+    setModals((prev) => ({
+      ...prev,
+      [id]: { isOpen: true },
+    }));
   };
 
-  const openModal = () => {
-    setIsOpen(true);
+  const closeModal = (id: string) => {
+    setModals((prev) => ({
+      ...prev,
+      [id]: { isOpen: false },
+    }));
   };
 
-  const closeModal = () => {
-    setIsOpen(false);
+  const toggleModal = (id: string) => {
+    setModals((prev) => ({
+      ...prev,
+      [id]: { isOpen: prev[id]?.isOpen !== true },
+    }));
+  };
+
+  const checkIsModalOpen = (id: string) => {
+    return !!modals[id]?.isOpen;
   };
 
   return (
-    <ModalContext.Provider value={{ toggleModal, openModal, closeModal, isOpen }}>
+    <ModalContext.Provider
+      value={{
+        openModal,
+        closeModal,
+        toggleModal,
+        checkIsModalOpen,
+      }}
+    >
       {children}
     </ModalContext.Provider>
   );

--- a/src/components/common/modal/ui/ModalCloseButton.tsx
+++ b/src/components/common/modal/ui/ModalCloseButton.tsx
@@ -4,18 +4,23 @@ import clsx from 'clsx';
 import xIcon from '@/../public/icons/x-icon.svg';
 import useModalContext from '@/components/common/modal/core/useModalContext';
 
+interface ModalCloseButtonProps extends React.ComponentProps<'button'> {
+  modalId: string;
+}
+
 export default function ModalCloseButton({
+  modalId,
   className,
   onClick,
   ...props
-}: React.ComponentProps<'button'>) {
+}: ModalCloseButtonProps) {
   const { closeModal } = useModalContext();
 
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
     if (onClick) {
       onClick(e);
     }
-    closeModal();
+    closeModal(modalId);
   };
 
   return (

--- a/src/components/common/modal/ui/ModalOverlay.tsx
+++ b/src/components/common/modal/ui/ModalOverlay.tsx
@@ -3,16 +3,21 @@ import { useEffect } from 'react';
 import clsx from 'clsx';
 import useModalContext from '@/components/common/modal/core/useModalContext';
 
+interface ModalOverlayProps extends React.ComponentProps<'div'> {
+  modalId: string;
+}
+
 export default function ModalOverlay({
+  modalId,
   className,
   children,
   ...props
-}: React.ComponentProps<'div'>) {
+}: ModalOverlayProps) {
   const { closeModal } = useModalContext();
 
   const handleClick = (e: React.MouseEvent<HTMLDivElement>) => {
     if (e.target === e.currentTarget) {
-      closeModal();
+      closeModal(modalId);
     }
   };
 

--- a/src/components/common/modal/ui/ModalTrigger.tsx
+++ b/src/components/common/modal/ui/ModalTrigger.tsx
@@ -1,14 +1,14 @@
 'use client';
 import useModalContext from '@/components/common/modal/core/useModalContext';
 
-export default function ModalTrigger({
-  onClick,
-  children,
-  ...props
-}: React.ComponentProps<'button'>) {
+interface ModalTriggerProps extends React.ComponentProps<'button'> {
+  modalId: string;
+}
+
+export default function ModalTrigger({ modalId, onClick, children, ...props }: ModalTriggerProps) {
   const { openModal } = useModalContext();
   const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-    openModal();
+    openModal(modalId);
     if (onClick) {
       onClick(e);
     }


### PR DESCRIPTION
## 🔎 작업 사항 
ModalProvider를 전역으로 옮기면서 한 페이지에 서로 다른 Modal을 띄우지 못하는 오류가 생겼고, 이 문제를 해결했습니다.
모달마다 id를 넘기고 Provider에서 객체를 관리하는 식으로 로직 수정. 

## ❗️ 전달 사항

모달을 관련 함수와 컴포넌트에 `modalId` prop을 넘겨줘야 합니다.

예시
```tsx 
import { ModalPortal, ModalTrigger } from '@/components/common/modal';
import FirstModal from './_home/FirstModal';
import SecondModal from './_home/SeconModal';

export default function Home() {
  return (
    <div>
      <ModalTrigger modalId="1">1번 열기</ModalTrigger>
      <ModalTrigger modalId="2">2번 열기</ModalTrigger>
      <ModalPortal modalId="1">
        <FirstModal modalId="1" />
      </ModalPortal>
      <ModalPortal modalId="2">
        <SecondModal modalId="2" />
      </ModalPortal>
    </div>
  );
}

// FirstModal
import { ModalCloseButton, ModalContainer, ModalOverlay } from '@/components/common/modal';

export default function FirstModal({ modalId }: { modalId: string }) {
  return (
    <ModalOverlay modalId={modalId}>
      <ModalContainer>
        <ModalCloseButton modalId={modalId} />
        1번 모달입니다.
      </ModalContainer>
    </ModalOverlay>
  );
}

```


## ➕ 관련 이슈 
