### PR TITLE
Refactor : user 데이터 전역 상태로 관리

### DIFF
--- a/src/api/user.ts
+++ b/src/api/user.ts
@@ -1,0 +1,4 @@
+import axiosClient from '@/lib/axiosClient';
+import { getUserApiResponse } from '@/types/user';
+
+export const getUser = () => axiosClient.get<getUserApiResponse>('/user');

--- a/src/app/(form-layout)/login/_login/LoginForm.tsx
+++ b/src/app/(form-layout)/login/_login/LoginForm.tsx
@@ -2,6 +2,7 @@
 import { useRef, useState, useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import axios, { CancelTokenSource, isAxiosError } from 'axios';
+import { useUser } from '@/contexts/UserContext';
 import FormField from '@/components/common/formField';
 import Button from '@/components/common/Button';
 import PasswordToggleButton from '@/app/(form-layout)/signup/_signup/PasswordToggleButton';
@@ -22,6 +23,7 @@ export default function LoginForm() {
   const router = useRouter();
   const cancelTokenRef = useRef<CancelTokenSource | null>(null);
 
+  const { fetchUser } = useUser();
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [isPasswordVisible, setIsPasswordVisible] = useState(false);
@@ -54,6 +56,7 @@ export default function LoginForm() {
       const data = res.data;
       setClientCookie('accessToken', data.accessToken);
       setClientCookie('refreshToken', data.refreshToken);
+      fetchUser();
       router.push(PATHS.HOME);
       setIsLoggingIn(false);
     } catch (error) {

--- a/src/app/_home/StartButton.tsx
+++ b/src/app/_home/StartButton.tsx
@@ -1,37 +1,31 @@
 'use client';
-import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { useUser } from '@/contexts/UserContext';
 import Button from '@/components/common/Button';
-import axiosClient from '@/lib/axiosClient';
 import PATHS from '@/constants/paths';
-import { getUserApiResponse } from '@/types/user';
 
-// @FIXME: 1. 유저 정보를 전역 상태로 관리해서, 요청 수 줄이기  2 href를 state로 관리 + Link 컴포넌트 사용
 export default function StartButton({
   className,
   children,
   ...props
 }: React.ComponentProps<'button'>) {
-  const router = useRouter();
-  const handleClick = async () => {
-    const res = await axiosClient.get<getUserApiResponse>(`/user`);
+  const { memberships } = useUser();
+  const [href, setHref] = useState('');
 
-    const memberships = res.data?.memberships || [];
-
-    router.push(
-      memberships.length > 0 ? `${PATHS.getGroupPath(memberships[0].groupId)}` : `${PATHS.NOGROUP}`
-    );
-  };
+  useEffect(() => {
+    if (memberships !== null && memberships[0] !== null) {
+      setHref(`${PATHS.getGroupPath(memberships[0].group.id)}`);
+    } else {
+      setHref(`${PATHS.LOGIN}`);
+    }
+  }, [setHref, memberships]);
 
   return (
-    <Button
-      variant="gradient"
-      fontSize="16"
-      size="xl"
-      onClick={handleClick}
-      className={className}
-      {...props}
-    >
-      {children}
-    </Button>
+    <Link href={href}>
+      <Button variant="gradient" fontSize="16" size="xl" className={className} {...props}>
+        {children}
+      </Button>
+    </Link>
   );
 }

--- a/src/app/_home/StartButton.tsx
+++ b/src/app/_home/StartButton.tsx
@@ -1,29 +1,29 @@
 'use client';
-import { useEffect, useState } from 'react';
 import Link from 'next/link';
 import { useUser } from '@/contexts/UserContext';
 import Button from '@/components/common/Button';
+import Spinner from '@/components/common/spinner';
 import PATHS from '@/constants/paths';
 
-export default function StartButton({
-  className,
-  children,
-  ...props
-}: React.ComponentProps<'button'>) {
-  const { memberships } = useUser();
-  const [href, setHref] = useState('');
+export default function StartButton({ className, children }: React.ComponentProps<'button'>) {
+  const { memberships, isLoading } = useUser();
 
-  useEffect(() => {
-    if (memberships !== null && memberships[0] !== null) {
-      setHref(`${PATHS.getGroupPath(memberships[0].group.id)}`);
-    } else {
-      setHref(`${PATHS.LOGIN}`);
-    }
-  }, [setHref, memberships]);
+  if (isLoading) {
+    return (
+      <Button variant="gradient" fontSize="16" size="xl" className={className} disabled>
+        <Spinner className="flex size-6 items-center justify-center" />
+      </Button>
+    );
+  }
+
+  const determinedHref =
+    memberships && memberships.length > 0 && memberships[0]?.group?.id
+      ? PATHS.getGroupPath(memberships[0].group.id)
+      : PATHS.LOGIN;
 
   return (
-    <Link href={href}>
-      <Button variant="gradient" fontSize="16" size="xl" className={className} {...props}>
+    <Link href={determinedHref} className={className}>
+      <Button variant="gradient" fontSize="16" size="xl">
         {children}
       </Button>
     </Link>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import './globals.css';
 import Header from '@/components/layout/gnb/Header';
 import { ModalProvider } from '@/components/common/modal';
 import ToastProvider from '@/components/common/Toastify/ToasProvider';
+import { UserProvider } from '@/contexts/UserContext';
 
 export const metadata: Metadata = {
   title: 'Coworkers',
@@ -17,11 +18,13 @@ export default function RootLayout({
     <html lang="ko">
       <body className="flex min-h-screen flex-col">
         <ModalProvider>
-          <Header />
-          <ToastProvider>
-            <div className="h-full flex-1 overflow-y-auto">{children}</div>
-          </ToastProvider>
-          <div id="modal-container"></div>
+          <UserProvider>
+            <Header />
+            <ToastProvider>
+              <div className="h-full flex-1 overflow-y-auto">{children}</div>
+            </ToastProvider>
+            <div id="modal-container"></div>
+          </UserProvider>
         </ModalProvider>
       </body>
     </html>

--- a/src/components/common/dropdown/ProfileItem.tsx
+++ b/src/components/common/dropdown/ProfileItem.tsx
@@ -1,7 +1,5 @@
-import Link from 'next/link';
-import { useUser } from '@/contexts/UserContext';
 import { deleteClientCookie } from '@/lib/cookie/client';
-import PATHS from '@/constants/paths';
+import Link from 'next/link';
 
 const PROFILE_DROPDOWN_LIST = [
   { text: '마이 히스토리', src: '/myhistory' },
@@ -10,28 +8,25 @@ const PROFILE_DROPDOWN_LIST = [
   { text: '로그아웃', src: '' },
 ];
 
-export default function DropDownProfileItemList() {
-  const { logoutUser } = useUser();
+const DropDownProfileItemList = PROFILE_DROPDOWN_LIST.map((list, index) => {
+  const isLast = index === PROFILE_DROPDOWN_LIST.length - 1;
 
   const handleClickLogOut = () => {
-    logoutUser();
     deleteClientCookie('accessToken');
     deleteClientCookie('refreshToken');
     location.reload();
-    window.location.href = `${PATHS.LOGIN}`;
+    window.location.href = '/login';
   };
 
-  return PROFILE_DROPDOWN_LIST.map((list, index) => {
-    const isLast = index === PROFILE_DROPDOWN_LIST.length - 1;
+  return isLast ? (
+    <button type="button" onClick={handleClickLogOut} key={list.text}>
+      {list.text}
+    </button>
+  ) : (
+    <Link href={list.src} key={list.text}>
+      {list.text}
+    </Link>
+  );
+});
 
-    return isLast ? (
-      <button type="button" onClick={handleClickLogOut} key={list.text}>
-        {list.text}
-      </button>
-    ) : (
-      <Link href={list.src} key={list.text}>
-        {list.text}
-      </Link>
-    );
-  });
-}
+export default DropDownProfileItemList;

--- a/src/components/common/dropdown/ProfileItem.tsx
+++ b/src/components/common/dropdown/ProfileItem.tsx
@@ -1,5 +1,7 @@
-import { deleteClientCookie } from '@/lib/cookie/client';
 import Link from 'next/link';
+import { useUser } from '@/contexts/UserContext';
+import { deleteClientCookie } from '@/lib/cookie/client';
+import PATHS from '@/constants/paths';
 
 const PROFILE_DROPDOWN_LIST = [
   { text: '마이 히스토리', src: '/myhistory' },
@@ -8,25 +10,28 @@ const PROFILE_DROPDOWN_LIST = [
   { text: '로그아웃', src: '' },
 ];
 
-const DropDownProfileItemList = PROFILE_DROPDOWN_LIST.map((list, index) => {
-  const isLast = index === PROFILE_DROPDOWN_LIST.length - 1;
+export default function DropDownProfileItemList() {
+  const { logoutUser } = useUser();
 
   const handleClickLogOut = () => {
+    logoutUser();
     deleteClientCookie('accessToken');
     deleteClientCookie('refreshToken');
     location.reload();
-    window.location.href = '/login';
+    window.location.href = `${PATHS.LOGIN}`;
   };
 
-  return isLast ? (
-    <button type="button" onClick={handleClickLogOut} key={list.text}>
-      {list.text}
-    </button>
-  ) : (
-    <Link href={list.src} key={list.text}>
-      {list.text}
-    </Link>
-  );
-});
+  return PROFILE_DROPDOWN_LIST.map((list, index) => {
+    const isLast = index === PROFILE_DROPDOWN_LIST.length - 1;
 
-export default DropDownProfileItemList;
+    return isLast ? (
+      <button type="button" onClick={handleClickLogOut} key={list.text}>
+        {list.text}
+      </button>
+    ) : (
+      <Link href={list.src} key={list.text}>
+        {list.text}
+      </Link>
+    );
+  });
+}

--- a/src/components/common/spinner/index.tsx
+++ b/src/components/common/spinner/index.tsx
@@ -1,0 +1,30 @@
+import clsx from 'clsx';
+
+type SpinnerProps = {
+  className?: string;
+};
+
+export default function Spinner({ className = '' }: SpinnerProps) {
+  return (
+    <svg
+      className={clsx('animate-spin text-white', className)}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+    >
+      <circle
+        className="opacity-25"
+        cx="12"
+        cy="12"
+        r="10"
+        stroke="currentColor"
+        stroke-width="4"
+      ></circle>
+      <path
+        className="opacity-75"
+        fill="currentColor"
+        d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"
+      ></path>
+    </svg>
+  );
+}

--- a/src/components/common/spinner/index.tsx
+++ b/src/components/common/spinner/index.tsx
@@ -18,7 +18,7 @@ export default function Spinner({ className = '' }: SpinnerProps) {
         cy="12"
         r="10"
         stroke="currentColor"
-        stroke-width="4"
+        strokeWidth="4"
       ></circle>
       <path
         className="opacity-75"

--- a/src/components/mypage-modal/ConfirmDeleteAccountModal.tsx
+++ b/src/components/mypage-modal/ConfirmDeleteAccountModal.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import Image from 'next/image';
+import { useUser } from '@/contexts/UserContext';
 import {
   ModalContainer,
   ModalDescription,
@@ -17,6 +18,7 @@ import { deleteClientCookie } from '@/lib/cookie/client';
 
 export default function ConfirmDeleteAccountModal() {
   const { closeModal } = useModalContext();
+  const { logoutUser } = useUser();
 
   return (
     <>
@@ -49,6 +51,7 @@ export default function ConfirmDeleteAccountModal() {
                   onClick={async () => {
                     try {
                       await axiosClient.delete('/user');
+                      logoutUser();
                       deleteClientCookie('accessToken');
                       deleteClientCookie('refreshToken');
                       Toast.success('회원 탈퇴가 완료되었습니다. 잠시 후 페이지가 이동합니다.');

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -7,6 +7,7 @@ import React, {
   ReactNode,
   useCallback,
 } from 'react';
+import { getClientCookie, deleteClientCookie } from '@/lib/cookie/client';
 import { Membership, User } from '@/types/user';
 import { getUser } from '@/api/user';
 
@@ -26,6 +27,9 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   const [memberships, setMemberships] = useState<Membership[] | null>(null);
 
   const fetchUser = useCallback(async () => {
+    const accessToken = getClientCookie('accessToken');
+    if (!accessToken) return;
+
     try {
       const response = await getUser();
       const { id, nickname, image, email, memberships } = response.data;
@@ -36,8 +40,10 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
       setUser(null);
       setEmail(null);
       setMemberships(null);
+      deleteClientCookie('accessToken');
+      deleteClientCookie('refreshToken');
     }
-  }, [setUser, setEmail, setMemberships]);
+  }, [setUser, setEmail]);
 
   useEffect(() => {
     fetchUser();

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,0 +1,72 @@
+'use client';
+import React, {
+  createContext,
+  useContext,
+  useState,
+  useEffect,
+  ReactNode,
+  useCallback,
+} from 'react';
+import { getClientCookie, deleteClientCookie } from '@/lib/cookie/client';
+import { Membership, User } from '@/types/user';
+import { getUser } from '@/api/user';
+
+interface UserContextType {
+  user: User | null;
+  email: string | null;
+  memberships: Membership[] | null;
+  logoutUser: () => Promise<void>;
+  fetchUser: () => Promise<void>;
+}
+
+const UserContext = createContext<UserContextType | null>(null);
+
+export const UserProvider = ({ children }: { children: ReactNode }) => {
+  const [user, setUser] = useState<User | null>(null);
+  const [email, setEmail] = useState<string | null>(null);
+  const [memberships, setMemberships] = useState<Membership[] | null>(null);
+
+  const fetchUser = useCallback(async () => {
+    const accessToken = getClientCookie('accessToken');
+
+    if (accessToken) {
+      try {
+        const response = await getUser();
+        const { id, nickname, image, email, memberships } = response.data;
+        setUser({ id, nickname, image });
+        setEmail(email);
+        setMemberships(memberships);
+      } catch {
+        setUser(null);
+        setEmail(null);
+        setMemberships(null);
+        deleteClientCookie('accessToken');
+        deleteClientCookie('refreshToken');
+      }
+    } else {
+      setUser(null);
+    }
+  }, []);
+
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
+
+  const logoutUser = useCallback(async () => {
+    deleteClientCookie('accessToken');
+    deleteClientCookie('refreshToken');
+    window.location.href = '/login';
+  }, []);
+
+  return (
+    <UserContext.Provider value={{ user, email, memberships, logoutUser, fetchUser }}>
+      {children}
+    </UserContext.Provider>
+  );
+};
+
+export const useUser = (): UserContextType => {
+  const ctx = useContext(UserContext);
+  if (!ctx) throw new Error('useUser must be used within UserProvider');
+  return ctx;
+};

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -1,12 +1,5 @@
 'use client';
-import React, {
-  createContext,
-  useContext,
-  useState,
-  useEffect,
-  ReactNode,
-  useCallback,
-} from 'react';
+import { createContext, useContext, useState, useEffect, useCallback } from 'react';
 import { getClientCookie, deleteClientCookie } from '@/lib/cookie/client';
 import { Membership, User } from '@/types/user';
 import { getUser } from '@/api/user';
@@ -22,7 +15,7 @@ interface UserContextType {
 
 const UserContext = createContext<UserContextType | null>(null);
 
-export const UserProvider = ({ children }: { children: ReactNode }) => {
+export const UserProvider = ({ children }: { children: React.ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [email, setEmail] = useState<string | null>(null);
   const [memberships, setMemberships] = useState<Membership[] | null>(null);

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -15,8 +15,9 @@ interface UserContextType {
   user: User | null;
   email: string | null;
   memberships: Membership[] | null;
-  logoutUser: () => Promise<void>;
   fetchUser: () => Promise<void>;
+  logoutUser: () => Promise<void>;
+  isLoading: boolean;
 }
 
 const UserContext = createContext<UserContextType | null>(null);
@@ -25,10 +26,16 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   const [user, setUser] = useState<User | null>(null);
   const [email, setEmail] = useState<string | null>(null);
   const [memberships, setMemberships] = useState<Membership[] | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
 
   const fetchUser = useCallback(async () => {
+    setIsLoading(true);
     const accessToken = getClientCookie('accessToken');
-    if (!accessToken) return;
+
+    if (!accessToken) {
+      setIsLoading(false);
+      return;
+    }
 
     try {
       const response = await getUser();
@@ -43,12 +50,15 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
       deleteClientCookie('accessToken');
       deleteClientCookie('refreshToken');
     }
+    setIsLoading(false);
   }, [setUser, setEmail]);
 
   const logoutUser = useCallback(async () => {
+    setIsLoading(true);
     setUser(null);
     setEmail(null);
     setMemberships(null);
+    setIsLoading(false);
   }, [setUser, setEmail, setMemberships]);
 
   useEffect(() => {
@@ -56,7 +66,7 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   }, [fetchUser]);
 
   return (
-    <UserContext.Provider value={{ user, email, memberships, logoutUser, fetchUser }}>
+    <UserContext.Provider value={{ user, email, memberships, fetchUser, logoutUser, isLoading }}>
       {children}
     </UserContext.Provider>
   );

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -45,15 +45,15 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
     }
   }, [setUser, setEmail]);
 
-  useEffect(() => {
-    fetchUser();
-  }, [fetchUser]);
-
   const logoutUser = useCallback(async () => {
     setUser(null);
     setEmail(null);
     setMemberships(null);
   }, [setUser, setEmail, setMemberships]);
+
+  useEffect(() => {
+    fetchUser();
+  }, [fetchUser]);
 
   return (
     <UserContext.Provider value={{ user, email, memberships, logoutUser, fetchUser }}>

--- a/src/contexts/UserContext.tsx
+++ b/src/contexts/UserContext.tsx
@@ -7,7 +7,6 @@ import React, {
   ReactNode,
   useCallback,
 } from 'react';
-import { getClientCookie, deleteClientCookie } from '@/lib/cookie/client';
 import { Membership, User } from '@/types/user';
 import { getUser } from '@/api/user';
 
@@ -27,36 +26,28 @@ export const UserProvider = ({ children }: { children: ReactNode }) => {
   const [memberships, setMemberships] = useState<Membership[] | null>(null);
 
   const fetchUser = useCallback(async () => {
-    const accessToken = getClientCookie('accessToken');
-
-    if (accessToken) {
-      try {
-        const response = await getUser();
-        const { id, nickname, image, email, memberships } = response.data;
-        setUser({ id, nickname, image });
-        setEmail(email);
-        setMemberships(memberships);
-      } catch {
-        setUser(null);
-        setEmail(null);
-        setMemberships(null);
-        deleteClientCookie('accessToken');
-        deleteClientCookie('refreshToken');
-      }
-    } else {
+    try {
+      const response = await getUser();
+      const { id, nickname, image, email, memberships } = response.data;
+      setUser({ id, nickname, image });
+      setEmail(email);
+      setMemberships(memberships);
+    } catch {
       setUser(null);
+      setEmail(null);
+      setMemberships(null);
     }
-  }, []);
+  }, [setUser, setEmail, setMemberships]);
 
   useEffect(() => {
     fetchUser();
   }, [fetchUser]);
 
   const logoutUser = useCallback(async () => {
-    deleteClientCookie('accessToken');
-    deleteClientCookie('refreshToken');
-    window.location.href = '/login';
-  }, []);
+    setUser(null);
+    setEmail(null);
+    setMemberships(null);
+  }, [setUser, setEmail, setMemberships]);
 
   return (
     <UserContext.Provider value={{ user, email, memberships, logoutUser, fetchUser }}>


### PR DESCRIPTION
## 🔎 작업 사항 

Refactor : user 데이터 전역 상태로 관리
- 헤더, 홈페이지, 계정관리 등에서 사용되는 사용자 정보 데이터를 전역 컨텍스트로 관리합니다.
- 홈페이지의 시작 버튼/로그인 페이지의 로그인/헤더의 회원탈퇴를 수정했습니다.
- 로딩 스피너 컴포넌트를 만들었습니다.

## ❗️ 전달 사항

헤더-로그아웃은 수정하다보니 건드려야할 부분이 많아져서 보류하고, 회의하고 진행하면 좋겠습니다.

## ➕ 관련 이슈 

